### PR TITLE
Add gas measurements

### DIFF
--- a/test/ReciboGasTest.t.sol
+++ b/test/ReciboGasTest.t.sol
@@ -100,6 +100,15 @@ contract ReciboGasTest is GaslessTestBase, BigMsg {
         vm.stopPrank();
     }
 
+    /** 
+    * GAS TESTS
+    *
+    * Each test measures the gas cost of a function call with a message of a specific length.
+    * Foundry runs each unit test function as a single transaction. Since gas usage goes down when
+    * smart contracts modify "warm" (used) storage addresses, we want to ensure as many addresses
+    * as possible are cold. We do this by running measurement in a separate unit test function.
+    */
+
     function measure_transferWithMsg(uint256 len) public {
         string memory group = Strings.toString(len);
         info.message = BigMsg.getBytes(len);

--- a/test/mock/BigMsg.t.sol
+++ b/test/mock/BigMsg.t.sol
@@ -26,7 +26,7 @@ contract BigMsg {
     function generateBytes(uint256 len) internal pure returns (bytes memory) {
         bytes memory result = new bytes(len);
         for(uint i = 0; i < 5000; i++) {
-            result[i] = bytes1(uint8(i % 256));
+            result[i] = bytes1(uint8(i % 256)); // uint8 0-255
         }
         return result;
     }


### PR DESCRIPTION
Adds gas measurement tests that will be run as part of standard `forge test` unit tests. Output stored in `snapshots` directory.