### PR TITLE
chore: apply security best practices and onboard stepsecurity

### DIFF
--- a/.github/workflows/recibo_python_test.yaml
+++ b/.github/workflows/recibo_python_test.yaml
@@ -30,12 +30,14 @@ env:
 jobs:
   run_recibo_tests:
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      - name: Harden the runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
-          egress-policy: audit
+          egress-policy: block
+          policy: global-allowed-endpoints-policy
 
       - name: Check out repository code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/recibo_python_test.yaml
+++ b/.github/workflows/recibo_python_test.yaml
@@ -32,15 +32,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Update submodules
         run: git submodule update --init --recursive
         shell: bash
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e # v1.5.0
         with:
           version: nightly
 

--- a/.github/workflows/recibo_test.yaml
+++ b/.github/workflows/recibo_test.yaml
@@ -31,15 +31,20 @@ jobs:
   run_recibo_tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Update submodules
         run: git submodule update --init --recursive
         shell: bash
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e # v1.5.0
         with:
           version: nightly
 

--- a/.github/workflows/recibo_test.yaml
+++ b/.github/workflows/recibo_test.yaml
@@ -30,11 +30,14 @@ env:
 jobs:
   run_recibo_tests:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      - name: Harden the runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
-          egress-policy: audit
+          egress-policy: block
+          policy: global-allowed-endpoints-policy
 
       - name: Check out repository code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0


### PR DESCRIPTION
This pull request strengthens the security and reliability of the GitHub Actions workflows for Recibo by hardening the runner environment, updating permissions, and pinning action versions to specific commit SHAs. These changes help prevent unauthorized access and ensure consistent, reproducible builds.

Security enhancements:

* Added the `step-security/harden-runner` action to both `.github/workflows/recibo_test.yaml` and `.github/workflows/recibo_python_test.yaml` to block unauthorized egress traffic and apply a global allowed endpoints policy. [[1]](diffhunk://#diff-db171cefd68db20ef821c0616460923f63c2f3d726d1a1e57fcb3f5ea6d5baa1R33-R50) [[2]](diffhunk://#diff-319b3b725cd78e63041f0c834bc4b6094b67be9435f0060968f2058276653c79L33-R50)
* Introduced `permissions: id-token: write` to enable secure use of OpenID Connect tokens in both workflows. [[1]](diffhunk://#diff-db171cefd68db20ef821c0616460923f63c2f3d726d1a1e57fcb3f5ea6d5baa1R33-R50) [[2]](diffhunk://#diff-319b3b725cd78e63041f0c834bc4b6094b67be9435f0060968f2058276653c79L33-R50)

Reliability improvements:

* Updated `actions/checkout` and `foundry-rs/foundry-toolchain` actions to use specific commit SHAs instead of floating versions, reducing the risk of unexpected changes from upstream updates. [[1]](diffhunk://#diff-db171cefd68db20ef821c0616460923f63c2f3d726d1a1e57fcb3f5ea6d5baa1R33-R50) [[2]](diffhunk://#diff-319b3b725cd78e63041f0c834bc4b6094b67be9435f0060968f2058276653c79L33-R50)