### PR TITLE
security: validate messageFrom to prevent identity spoofing

### DIFF
--- a/src/Recibo.sol
+++ b/src/Recibo.sol
@@ -52,6 +52,7 @@ contract Recibo is ReciboEvents {
     function sendMsg(
         ReciboInfo calldata info
     ) public {
+        require(info.messageFrom == msg.sender, "Recibo: messageFrom must match sender");
         emit SentMsg(msg.sender, info.messageFrom, info.messageTo);
     }
 
@@ -67,6 +68,7 @@ contract Recibo is ReciboEvents {
         uint256 value,
         ReciboInfo calldata info
     ) public returns (bool) {
+        require(info.messageFrom == msg.sender, "Recibo: messageFrom must match sender");
         emit TransferWithMsg(msg.sender, to, info.messageFrom, info.messageTo, value);
         return _token.transferFrom(msg.sender, to, value);
     }
@@ -94,7 +96,9 @@ contract Recibo is ReciboEvents {
         bytes32 s,
         ReciboInfo calldata info
     ) public {
-        require(owner != address(this));
+        require(owner != address(this), "Recibo: owner cannot be this contract");
+        require(spender != address(this), "Recibo: spender cannot be this contract");
+        require(info.messageFrom == owner, "Recibo: messageFrom must match owner");
         emit ApproveWithMsg(owner, spender, info.messageFrom, info.messageTo, value);
         _token.permit(owner, spender, value, deadline, v, r, s);
     }
@@ -121,6 +125,7 @@ contract Recibo is ReciboEvents {
         bytes32 s,
         ReciboInfo calldata info
     ) public returns (bool) {
+        require(info.messageFrom == msg.sender, "Recibo: messageFrom must match sender");
         emit TransferWithMsg(msg.sender, to, info.messageFrom, info.messageTo, value);
         _token.permit(msg.sender, address(this), value, deadline, v, r, s);
         return _token.transferFrom(msg.sender, to, value);
@@ -148,6 +153,7 @@ contract Recibo is ReciboEvents {
         bytes memory signature,
         ReciboInfo calldata info
     ) public {
+        require(info.messageFrom == from, "Recibo: messageFrom must match from");
         emit TransferWithMsg(from, to, info.messageFrom, info.messageTo, value);
         _token.transferWithAuthorization(from, to, value, validAfter, validBefore, nonce, signature);
     }

--- a/src/ReciboToken.sol
+++ b/src/ReciboToken.sol
@@ -42,6 +42,7 @@ contract ReciboToken is ERC20, ReciboEvents {
       * @dev See {ERC20-transfer}.
       */
     function transferWithMsg(address to, uint256 value, address messageFrom, address messageTo, string calldata metadata, bytes calldata message) public returns (bool) {
+        require(messageFrom == msg.sender, "ReciboToken: messageFrom must match sender");
         emit TransferWithMsg(msg.sender, to, messageFrom, messageTo, value);
         return transfer(to, value);
     }
@@ -51,6 +52,7 @@ contract ReciboToken is ERC20, ReciboEvents {
       * @dev See {ERC20-approve}.
       */
     function approveWithMsg(address spender, uint256 value, address messageFrom, address messageTo, string calldata metadata, bytes calldata message) public returns (bool) {
+        require(messageFrom == msg.sender, "ReciboToken: messageFrom must match sender");
         emit ApproveWithMsg(msg.sender, spender, messageFrom, messageTo, value);
         return approve(spender, value);
     }
@@ -60,6 +62,7 @@ contract ReciboToken is ERC20, ReciboEvents {
      * @dev See {ERC20-transferFrom}.
      */
     function transferFromWithMsg(address from, address to, uint256 value, address messageFrom, address messageTo, string calldata metadata, bytes calldata message) public returns (bool) {
+        require(messageFrom == from, "ReciboToken: messageFrom must match from");
         emit TransferWithMsg(from, to, messageFrom, messageTo, value);
         return transferFrom(from, to, value);
     }

--- a/test/ReciboGasTest.t.sol
+++ b/test/ReciboGasTest.t.sol
@@ -33,7 +33,7 @@ contract ReciboGasTest is GaslessTestBase, BigMsg {
     address private minter;
     uint256 private minterKey;
     bytes private msgBytes = abi.encode("message");
-    Recibo.ReciboInfo private info = Recibo.ReciboInfo(minter, user, "metadata", msgBytes);
+    Recibo.ReciboInfo private info;
 
     uint private deadline;
     uint256 private validBefore;
@@ -41,6 +41,7 @@ contract ReciboGasTest is GaslessTestBase, BigMsg {
 
     function setUp() public {
         (minter, minterKey) = makeAddrAndKey("minter");
+        info = Recibo.ReciboInfo(minter, user, "metadata", msgBytes);
         deadline = makeDeadline(10);
         (validAfter, validBefore) = makeValidTime(100);
 


### PR DESCRIPTION
Validate messageFrom to prevent spoofing
Problem
messageFrom in ReciboInfo is not validated. Anyone can set it to an arbitrary address:

recibo.sendMsg(ReciboInfo({
    messageFrom: PAUL_ADDRESS,
    messageTo: victim,
    message: encrypted_msg,
    metadata: "{}"
}))
// Event shows "Paul sent message" but actual sender was attacker
This will get flagged in audit.

Solution
require(info.messageFrom == msg.sender, "Recibo: messageFrom must match sender");
Applied to all functions in both Recibo.sol and ReciboToken.sol.

Bonus: Added missing spender != address(this) check in permitWithMsg.

Potential pushback & responses
"We're adding AA soon, won't this block relayers?"
Yes, but that's the point. Current design has no signature verification - anyone can spoof.

When we add AA, we'll add separate functions:

sendMsg() - simple, direct calls (this PR)
sendMsgWithSignature() - supports relayers (Phase 2)
Both need to be secure. Can't ship AA with an insecure fallback function.

"But calldata has tx.from, so we can verify off-chain"
Events are for indexing. Not every UI/indexer will parse calldata for tx.from.
Attack vector: phishing notifications ("Circle sent you a message!").

Arc Chain = financial messaging with USDC gas = higher security bar.

"messageFrom is for flexibility"
Without signature verification, it's for spoofing.

AA requires EIP-712 signatures anyway. This PR doesn't prevent AA

Breaking change
Impact: Minimal. Python client already uses sender_address correctly.
Only affects hypothetical relayer code (which doesn't exist yet and would need signatures anyway).